### PR TITLE
validating only http urls

### DIFF
--- a/crawler/src/main.ts
+++ b/crawler/src/main.ts
@@ -75,8 +75,8 @@ const blockedWords = [
 
 function isValidUrl(url: string) {
   try {
-    new URL(url);
-    return true;
+    const newUrl = new URL(url);
+    return newUrl.protocol === 'http:' || newUrl.protocol === 'https:';
   } catch (_) {
     return false;
   }


### PR DESCRIPTION
it prevents other legitimate urls like "mailto:/mail@example.com."